### PR TITLE
Fix click actions on NVDA alpha snapshots: pass 0 instead of None to winUser.mouse_event

### DIFF
--- a/addon/globalPlugins/systrayList/__init__.py
+++ b/addon/globalPlugins/systrayList/__init__.py
@@ -28,7 +28,7 @@ def mouseEvents(location, *events):
 	winUser.setCursorPos (x,y)
 	#simulation of pressing mouse button
 	for event in events:
-		winUser.mouse_event(event, 0, 0, None, None)
+		winUser.mouse_event(event, 0, 0, 0, 0)
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):


### PR DESCRIPTION
### Summary of the issue


As of nvaccess/nvda#18883, several ctypes definitions in the winUser bindings were tightened or removed. As a result, winUser.mouse_event no longer accepts None for integer parameters. This causes the SysTrayList add-on to raise a TypeError when performing simulated clicks on current NVDA alpha snapshots.


### Description of development approach


This PR replaces None arguments passed to winUser.mouse_event with integer 0, which matches the Win32 API’s expected parameter types and preserves identical runtime behavior.

The change restores compatibility with the upcoming NVDA 2026.1 release while remaining valid for older releases, since the `mouse\\\_event` function has always accepted zero values for these parameters.

I did not modify buildVars.py to declare compatibility with NVDA 2026.1, as further API-breaking changes may occur before the final release.


### Testing strategy

Tested on:

* NVDA 2025.3 (stable)
* Latest NVDA alpha snapshot

Verified that all click actions (left, right, and double click) perform as expected in both environments.


### Known issues with this pull request


None.


### Future improvement


If maintainers prefer, the click simulation could later be updated to use NVDA’s mouseHandler API (doPrimaryClick, doSecondaryClick) for improved maintainability. I’d be happy to explore that in a follow-up PR.
